### PR TITLE
Fix multi-byte comment handle. If \n is contained in trailing-byte, it shouldn't be handled as multi-byte.

### DIFF
--- a/get.c
+++ b/get.c
@@ -494,9 +494,10 @@ static int skipOverCplusComment (void)
 		mblen = mbcs_lead_byte(c);
 		if (mblen)
 		{
-			for (ki = 0; ki < mblen-1; ki++)
-				fileGetc();
-			continue;
+			for (ki = 0; ki < mblen-1 && c != NEWLINE; ki++)
+				c = fileGetc();
+			if (c != NEWLINE)
+				continue;
 		}
 #endif
 		if (c == BACKSLASH)
@@ -556,9 +557,10 @@ static int skipToEndOfChar (void)
 		mblen = mbcs_lead_byte(c);
 		if (mblen)
 		{
-			for (ki = 0; ki < mblen-1; ki++)
-				fileGetc();
-			continue;
+			for (ki = 0; ki < mblen-1 && c != NEWLINE; ki++)
+				c = fileGetc();
+			if (c != NEWLINE)
+				continue;
 		}
 #endif
 	    ++count;


### PR DESCRIPTION
This is illegal case I know. When missed to specify `-jcode` option, for example run ctags without any options on windows(i.e.: this works as -jcode=sjis), and code is utf-8 encoded,
ctags skip the bytes though it's NEWLINE. Below is a way to reproduce.

``` java
package ctags.example;

public class Foo {
    public void doIt() {
        try {
            // あ
            if (true) {
            }
        } catch (Throwable e) {
        }
    }
}
```

NOTE, This won't reproduce except windows.
`Foo.java` is utf-8 encoded. Then `あ` takes 3bytes. Run just `ctags.exe` not specified any arguments.

```
!_TAG_FILE_ENCODING cp932   //
!_TAG_FILE_FORMAT   2   /extended format; --format=1 will not append ;" to lines/
!_TAG_FILE_SORTED   1   /0=unsorted, 1=sorted, 2=foldcase/
!_TAG_PROGRAM_AUTHOR    Darren Hiebert  /dhiebert@users.sourceforge.net/
!_TAG_PROGRAM_JP_AUTHOR HIGASHI Hirohito    /Twitter: @h_east/
!_TAG_PROGRAM_JP_URL    http://hp.vector.co.jp/authors/VA025040/    //
!_TAG_PROGRAM_NAME  Exuberant Ctags //
!_TAG_PROGRAM_URL   http://ctags.sourceforge.net    /official site/
!_TAG_PROGRAM_VERSION   5.8J2   //
Foo .\UserResource.java /^public class Foo {$/;"    c
catch   .\UserResource.java /^      } catch (Throwable e) {$/;" m   class:Foo
ctags.example   .\UserResource.java /^package ctags.example;$/;"    p
doIt    .\UserResource.java /^  public void doIt() {$/;"    m   class:Foo
```

`catch` is not a method, but it entered on tags file.
