### PR TITLE
Fixed compilation problem on MinGW

### DIFF
--- a/general.h
+++ b/general.h
@@ -57,7 +57,11 @@
  *  to prevent warnings about unused variables.
  */
 #if (__GNUC__ > 2  ||  (__GNUC__ == 2  &&  __GNUC_MINOR__ >= 7)) && !defined (__GNUG__)
-# define __unused__  __attribute__((unused))
+# ifdef __MINGW32__
+#  define __unused__
+# else
+#  define __unused__  __attribute__((unused))
+# endif
 # define __printf__(s,f)  __attribute__((format (printf, s, f)))
 #else
 # define __unused__

--- a/mk_mingw.mak
+++ b/mk_mingw.mak
@@ -5,16 +5,15 @@
 
 include source.mak
 
-#REGEX_DEFINES = -DHAVE_REGCOMP -D__USE_GNU -Dbool=int -Dfalse=0 -Dtrue=1 -Dstrcasecmp=stricmp
-REGEX_DEFINES = -DHAVE_REGCOMP -Dstrcasecmp=stricmp
+REGEX_DEFINES = -DHAVE_REGCOMP -D__USE_GNU -Dbool=int -Dfalse=0 -Dtrue=1 -Dstrcasecmp=stricmp
 
 CFLAGS = -Wall
-##DEFINES = -DWIN32 $(REGEX_DEFINES)
 DEFINES = -DWIN32 $(REGEX_DEFINES) -DHAVE_ICONV
 INCLUDES = -I. -Ignu_regex
 CC = gcc
 OBJEXT = o
-LDFLAGS = -liconv.dll
+LDFLAGS = -liconv
+OBJECTS += $(REGEX_SOURCES:%.c=%.o)
 
 ctags.exe: OPT = -O4
 dctags.exe: OPT = -g
@@ -29,7 +28,7 @@ dctags.exe: SOURCES += debug.c
 ctags: ctags.exe
 
 ctags.exe dctags.exe: $(OBJECTS) $(HEADERS) $(REGEX_HEADERS)
-	$(CC) $(OPT) $(CFLAGS) $(DEFINES) $(INCLUDES) -o $@ $(OBJECTS) $(REGEX_SOURCES:%.c=%.o) $(LDFLAGS)
+	$(CC) $(OPT) $(CFLAGS) $(DEFINES) $(INCLUDES) -o $@ $(OBJECTS) $(LDFLAGS)
 
 readtags.exe: readtags.c
 	$(CC) $(OPT) $(CFLAGS) -DREADTAGS_MAIN $(DEFINES) $(INCLUDES) -o $@ $<


### PR DESCRIPTION
MinGW でコンパイルできなくなっていたのを直してみました。
1. `general.h` で `__unused__` を定義しているため、`stdio.h` からインクルードされる `swprintf.inl` の `__attribute__((__unused__))` の意味が変わってしまいコンパイルエラーになる。
2. `-liconv.dll` -> `-liconv`
3. #12 で `mk_mingw.mak` にサフィックスルールが追加されましたが、`OBJECTS` に `gnu_regex/regex.o` が含まれていないためにコンパイルされず、リンクエラーになる。
