### PR TITLE
Fixed compilation problem on MSVC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *~
 *.swp
 *.o
+*.obj
 *.od
 
 Makefile
@@ -17,5 +18,7 @@ ctags.ref
 tags.ref
 test.*.diff
 syntax.vim
+*.exe
+respmvc
 
 tags

--- a/gnu_regex/regcomp.c
+++ b/gnu_regex/regcomp.c
@@ -927,9 +927,9 @@ static void
 internal_function
 init_word_char (re_dfa_t *dfa)
 {
-  dfa->word_ops_used = 1;
   int i = 0, j;
   int ch = 0;
+  dfa->word_ops_used = 1;
   if (BE (dfa->map_notascii == 0, 1))
     {
       if (sizeof (dfa->word_char[0]) == 8)

--- a/gnu_regex/regex_internal.h
+++ b/gnu_regex/regex_internal.h
@@ -416,6 +416,10 @@ static unsigned int re_string_context_at (const re_string_t *input, int idx,
 
 #ifdef WIN32
 # include <malloc.h>
+# ifdef _MSC_VER
+#  define __attribute(arg)
+#  define inline __inline
+# endif
 #else
 # include <alloca.h>
 #endif


### PR DESCRIPTION
MSVC でコンパイルできなくなっていたのを直してみました。

変更内容は `__attribute` の定義の追加と、C99 に対応していない MSVC 用の修正です。
ついでに `mk_mvc.mak` でコンパイルすると生成されるものを `.gitignore` に追加しました。
