### PR TITLE
Update options.c so it can compile on Sun

### DIFF
--- a/options.c
+++ b/options.c
@@ -668,7 +668,8 @@ static void addExtensionList (
 	}
 	while (extension != NULL)
 	{
-		char *separator = strchr (extension, EXTENSION_SEPARATOR);
+		char *separator = strchr (const_cast<char *>(extension),
+				EXTENSION_SEPARATOR);
 		if (separator != NULL)
 			*separator = '\0';
 		verbose ("%s%s", first ? "" : ", ",


### PR DESCRIPTION
Hi Guys,

I'm a heavy user of ctags and I love it thanks for all your hard work. I wanted to compile the latest version on ctags on a Sun/Solaris server at work, I don't have root access and asking IT to do it is a pain. So I thought compiling it myself was a better option. I compiled it pretty quickly thanks for making it so easy!

But I also have bad news the following doesn't compile on Sun so I removed them from my build because I did not want their functionality:

asm.c
eiffel.c
flex.c
fortran.c
jscript.c
ocaml.c
python.c
sql.c
tex.c
vhdl.c

But I did make a code change to options.c as it seemed like a pretty important file to compile. This is the error you receive if you try to compile without this code change:

"options.c", line 661: Error: Cannot use const char\* to initialize char*.

I made my decision based on this:

http://stackoverflow.com/a/833114

I have no knowledge of the codebase so I thought this change would have the most minimal effect. I will leave you decide if you want to ifdef around it so that this change only occurs during the Sun compile.

Regards,

Eric Curtin
