### PR TITLE
use travis's new stack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,4 @@ script:
   - make
   - cp ./dctags ctags.ref
   - make test CTAGS_TEST=./dctags
+sudo: false


### PR DESCRIPTION
According to [this travis blog](http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/),  this makes starting of build faster.
