### PR TITLE
Fix EncodingMap related memory management bugs

### DIFF
--- a/parse.c
+++ b/parse.c
@@ -657,11 +657,12 @@ static unsigned int EncodingMapMax;
 static void addLanguageEncoding (const langType language,
 									const char *const encoding __unused__)
 {
-	if (language > EncodingMapMax)
+	if (language > EncodingMapMax || EncodingMapMax == 0)
 	{
 		int i;
+		int istart = (EncodingMapMax == 0)? 0: EncodingMapMax + 1;
 		EncodingMap = xRealloc (EncodingMap, (language + 1), char*);
-		for (i = EncodingMapMax + 1  ;  i <= language  ;  ++i)
+		for (i = istart;  i <= language  ;  ++i)
 		{
 			EncodingMap [i] = NULL;
 		}
@@ -693,7 +694,7 @@ extern void freeEncodingResources (void)
 	if (EncodingMap)
 	{
 		int i;
-		for (i = 0  ;  i < EncodingMapMax  ; ++i)
+		for (i = 0  ;  i <= EncodingMapMax  ; ++i)
 		{
 			if (EncodingMap [i])
 				eFree (EncodingMap [i]);


### PR DESCRIPTION
--encoding-<LANG> has two troubles in memory management.

I1. About initializing EncodingMap[0]

   EncodingMap[0] is handled special in addLanguageEncoding;
   EncodingMap[0] is never initialized.

   As the result an encoding cannot be specified to ANT parser
   which is put in EncodingMap[0].

   $ ./ctags  --encoding-ant=utf-8 c.c
   zsh: segmentation fault (core dumped)  ./ctags --encoding-ant=utf-8 c.c

I2. About freeing EncodingMap[0]

   Though EncodingMap[0] is never initialized, it is freed in
   freeEncodingResources. This causes a crash.

   $ ./ctags  --encoding-c=utf-8 c.c
   zsh: segmentation fault (core dumped)  ./ctags --encoding-c=utf-8 c.c

I3. About memory leak of EncodingMap[EncodingMapMax]

    Valgrind reports a memory object assigned to
    EncodingMap[EncodingMapMax], the last slot of array, will never be
    freed. freeEncodingResources doesn't free the last one.
    (Impact for users may be small.)

In this patch EncodingMap[0] is initialized with NULL when
EncodingMapMax is 0. This fixes I1 and I2.

In addition, `<', a comparison operator for finding the last slot is
replaced with `<='. This fixes I3.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>